### PR TITLE
Address CRAN feedback and drop rocleteer dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,12 +20,9 @@ Suggests:
     rmarkdown,
     quarto,
     withr,
-    testthat (>= 3.0.0),
-    rocleteer
+    testthat (>= 3.0.0)
 Encoding: UTF-8
-Roxygen: list(markdown = TRUE, packages = c("rocleteer"))
-RoxygenNote: 7.3.2
+Roxygen: list(markdown = TRUE)
 VignetteBuilder: quarto
 Config/testthat/edition: 3
-Remotes:
-  coatless-rpkg/rocleteer
+Config/roxygen2/version: 8.0.0

--- a/R/find.R
+++ b/R/find.R
@@ -27,20 +27,6 @@
 #'    - Returns immediately if valid app.json is found
 #'
 #' @keywords internal
-#'
-#' @examples
-#' \dontrun{
-#' # Direct app.json URL
-#' result <- find_shinylive_app_json("https://example.com/app.json")
-#'
-#' # Directory containing app.json
-#' result <- find_shinylive_app_json("https://example.com/myapp/")
-#'
-#' # Check if valid
-#' if (result$valid) {
-#'   cat("Found app.json at:", result$url)
-#' }
-#' }
 find_shinylive_app_json <- function(base_url) {
     # List of possible paths to try
     possible_paths <- c(
@@ -106,21 +92,6 @@ find_shinylive_app_json <- function(base_url) {
 #' options (prefixed with `'#|'`) and file markers (prefixed with `'## file:'`).
 #'
 #' @seealso parse_code_block
-#'
-#' @examples
-#' \dontrun{
-#' html_content <- '
-#' <pre class="shinylive-r" data-engine="r">
-#' #| viewerHeight: 500
-#' ## file: app.R
-#' library(shiny)
-#' ui <- fluidPage()
-#' server <- function(input, output) {}
-#' shinyApp(ui, server)
-#' </pre>
-#' '
-#' apps <- find_shinylive_code(html_content)
-#' }
 #'
 #' @keywords internal
 find_shinylive_code <- function(html) {

--- a/R/peek.R
+++ b/R/peek.R
@@ -10,7 +10,8 @@
 #'   - A directory containing `app.json`
 #'   - A Quarto document with embedded Shinylive applications
 #' @param output_dir Character string. Directory where the application files should
-#'   be extracted. Defaults to `"converted_shiny_app"`. Will be created if it doesn't exist.
+#'   be extracted. A relative path is created under the current working directory;
+#'   an absolute path is used as-is. The directory will be created if it doesn't exist.
 #'
 #' @return
 #' An object containing the extracted application information:
@@ -60,20 +61,19 @@
 #'
 #' @export
 #' @examplesIf interactive()
-#' # Download a standalone Shinylive application
+#' # Write the extracted files to the session's temporary directory
 #' url <- "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/"
-#'
-#' app <- peek_shinylive_app(url)
-#'
-#' # Extract to a specific directory
-#' app <- peek_shinylive_app(
-#'   url,
-#'   output_dir = "my_extracted_app"
-#' )
+#' app <- peek_shinylive_app(url, output_dir = file.path(tempdir(), "my_extracted_app"))
 #'
 #' # Download from a Quarto document
-#' apps <- peek_shinylive_app("https://quarto-ext.github.io/shinylive/")
-peek_shinylive_app <- function(url, output_dir = "converted_shiny_app") {
+#' apps <- peek_shinylive_app(
+#'   "https://quarto-ext.github.io/shinylive/",
+#'   output_dir = file.path(tempdir(), "my_extracted_apps")
+#' )
+peek_shinylive_app <- function(url, output_dir) {
+    # Resolve relative paths against the working directory
+    output_dir <- resolve_output_path(output_dir)
+
     # Download content
     resp <- httr::GET(url)
     if (httr::http_error(resp)) {
@@ -131,10 +131,11 @@ peek_shinylive_app <- function(url, output_dir = "converted_shiny_app") {
 #'   - `"app-dir"`: Creates separate directories for each application
 #'   - `"quarto"`: Combines all applications into a single Quarto document
 #'
-#' @param output_path Character string or NULL. Where to write the extracted
-#'   applications. If NULL, uses default paths:
-#'   - For "app-dir": "./converted_shiny_apps/"
-#'   - For "quarto": "./converted_shiny_apps.qmd"
+#' @param output_path Character string. Where to write the extracted
+#'   applications. A relative path is resolved against the current working
+#'   directory; an absolute path is used as-is.
+#'   - For `"app-dir"`: a directory that will hold the extracted applications
+#'   - For `"quarto"`: the path of the `.qmd` file to create
 #'
 #' @return
 #' An object of class `"shinylive_commands"` that provides:
@@ -175,35 +176,30 @@ peek_shinylive_app <- function(url, output_dir = "converted_shiny_app") {
 #'
 #' @export
 #' @examplesIf interactive()
-#' # Extract as separate applications
+#' # Extract as separate application directories under a temporary directory
 #' result <- peek_quarto_shinylive_app(
 #'   "https://quarto-ext.github.io/shinylive",
-#'   output_format = "app-dir"
+#'   output_format = "app-dir",
+#'   output_path = file.path(tempdir(), "quarto_apps")
 #' )
 #'
 #' # Combine into a new Quarto document
 #' result <- peek_quarto_shinylive_app(
 #'   "https://quarto-ext.github.io/shinylive",
 #'   output_format = "quarto",
-#'   output_path = "my_apps.qmd"
+#'   output_path = file.path(tempdir(), "my_apps.qmd")
 #' )
 #'
 #' # Print will show instructions for running the apps
 #' print(result)
 peek_quarto_shinylive_app <- function(url,
                                       output_format = c("app-dir", "quarto"),
-                                      output_path = NULL) {
+                                      output_path) {
     # Validate output format
     output_format <- match.arg(output_format)
 
-    # Set default output path if not provided
-    if (is.null(output_path)) {
-        output_path <- if (output_format == "app-dir") {
-            "converted_shiny_apps"
-        } else {
-            "converted_shiny_apps.qmd"
-        }
-    }
+    # Resolve relative paths against the working directory
+    output_path <- resolve_output_path(output_path)
 
     # Download and parse HTML
     resp <- httr::GET(url)
@@ -254,9 +250,9 @@ peek_quarto_shinylive_app <- function(url,
 #'   The function will automatically append `"app.json"` to directory URLs.
 #'
 #' @param output_dir Character string. Directory where the application files
-#'   should be extracted. Defaults to `"converted_shiny_app"`. Will be created
-#'   if it doesn't exist. If the directory already exists, files may be
-#'   overwritten.
+#'   should be extracted. A relative path is created under the current working
+#'   directory; an absolute path is used as-is. Will be created if it doesn't
+#'   exist. If the directory already exists, files may be overwritten.
 #'
 #' @return
 #' An object of class `"standalone_shinylive_app"` containing:
@@ -296,21 +292,24 @@ peek_quarto_shinylive_app <- function(url,
 #'
 #' @export
 #' @examplesIf interactive()
-#'
-#' # Download from a direct app.json URL
+#' # Download from a direct app.json URL into a temporary directory
 #' app <- peek_standalone_shinylive_app(
-#'   "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/app.json"
+#'   "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/app.json",
+#'   output_dir = file.path(tempdir(), "standalone_app")
 #' )
 #'
 #' # Download from a directory URL (app.json will be appended)
 #' app <- peek_standalone_shinylive_app(
 #'   "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/",
-#'   output_dir = "my_local_app"
+#'   output_dir = file.path(tempdir(), "my_local_app")
 #' )
 #'
 #' # Print shows how to run the application
 #' print(app)
-peek_standalone_shinylive_app <- function(url, output_dir = "converted_shiny_app") {
+peek_standalone_shinylive_app <- function(url, output_dir) {
+
+    # Resolve relative paths against the working directory
+    output_dir <- resolve_output_path(output_dir)
 
     # Find and validate URL for app.json
     # we append app.json to the URL as one of the possible paths

--- a/R/quarto-cell-parser.R
+++ b/R/quarto-cell-parser.R
@@ -35,31 +35,6 @@
 #' - `"app.R"` for R applications
 #' - `"app.py"` for Python applications
 #'
-#' @examples
-#' \dontrun{
-#' # Single-file R application
-#' code <- '
-#' #| viewerHeight: 500
-#' library(shiny)
-#' ui <- fluidPage()
-#' server <- function(input, output) {}
-#' shinyApp(ui, server)
-#' '
-#' result1 <- parse_code_block(code, "r")
-#'
-#' # Multi-file Python application
-#' code <- '
-#' #| fullWidth: true
-#' ## file: app.py
-#' from shiny import App, ui
-#' app = App(app_ui)
-#' ## file: requirements.txt
-#' ## type: text
-#' shiny>=0.5.0
-#' '
-#' result2 <- parse_code_block(code, "python")
-#' }
-#'
 #' @seealso
 #'
 #' - [parse_yaml_options()] for YAML-style option parsing
@@ -167,25 +142,6 @@ parse_code_block <- function(code_text, engine) {
 #'   - **Strings:** All other values
 #'
 #' Lines that don't contain a colon (`':'`) are ignored.
-#'
-#' @examples
-#' \dontrun{
-#' # Parse various types of options
-#' yaml_lines <- c(
-#'   "#| viewerHeight: 500",
-#'   "#| components: [slider,button]",
-#'   "#| fullWidth: true",
-#'   "#| title: My App"
-#' )
-#' options <- parse_yaml_options(yaml_lines)
-#' # Results in:
-#' # list(
-#' #   viewerHeight = 500,
-#' #   components = c("slider", "button"),
-#' #   fullWidth = TRUE,
-#' #   title = "My App"
-#' # )
-#' }
 #'
 #' @seealso parse_code_block
 #'

--- a/R/shinylive-quarto-apps-commands.R
+++ b/R/shinylive-quarto-apps-commands.R
@@ -25,6 +25,15 @@ create_quarto_shinylive_apps <- function(apps, output_format, output_path) {
 #' @param ... Additional arguments passed to print
 #'
 #' @export
+#' @return
+#' Invisibly returns the original object of class \code{quarto_shinylive_apps}.
+#' Primarily called for its side effect of displaying formatted information about:
+#' \itemize{
+#'   \item Application types (R/Python)
+#'   \item Commands to run each application
+#'   \item File contents and organization
+#'   \item Output locations
+#' }
 print.quarto_shinylive_apps <- function(x, ...) {
 
     # Style definitions

--- a/R/shinylive-standalone-app-commands.R
+++ b/R/shinylive-standalone-app-commands.R
@@ -25,6 +25,15 @@ create_standalone_shinylive_app <- function(app_data, output_dir, url) {
 #' @param ... Additional arguments passed to print
 #'
 #' @export
+#' @return
+#' Invisibly returns the original object of class \code{standalone_shinylive_app}.
+#' Primarily called for its side effect of displaying formatted information about:
+#' \itemize{
+#'   \item Application type (R/Python)
+#'   \item Command to run the application
+#'   \item List of extracted files by type
+#'   \item File locations
+#' }
 print.standalone_shinylive_app <- function(x, ...) {
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -56,30 +56,6 @@
 #' - [find_shinylive_app_json()] which uses this validation
 #'
 #' @keywords internal
-#'
-#' @examples
-#' \dontrun{
-#' # Valid structure
-#' valid_data <- list(
-#'   list(
-#'     name = "app.R",
-#'     content = "library(shiny)\n...",
-#'     type = "text"
-#'   ),
-#'   list(
-#'     name = "data.csv",
-#'     content = "x,y\n1,2",
-#'     type = "text"
-#'   )
-#' )
-#' validate_app_json(valid_data)  # Returns TRUE
-#'
-#' # Invalid structures that will error:
-#' validate_app_json(list())  # Empty list
-#' validate_app_json(list(
-#'   list(name = "app.R")  # Missing required fields
-#' ))
-#' }
 validate_app_json <- function(json_data) {
     if (!is.list(json_data)) {
         cli::cli_abort(c(
@@ -131,5 +107,24 @@ validate_app_json <- function(json_data) {
 padding_width <- function(n) {
     if (n <= 0) return(1)
     floor(log10(n)) + 1
+}
+
+#' Resolve an output path against the working directory
+#'
+#' Absolute (\dQuote{global}) paths are returned unchanged; relative paths are
+#' resolved against the current working directory so that callers always work
+#' with a fully qualified location and never silently write somewhere
+#' unexpected.
+#'
+#' @param path Character string. A user-supplied output path.
+#'
+#' @return Character string giving an absolute path.
+#'
+#' @noRd
+resolve_output_path <- function(path) {
+    if (!fs::is_absolute_path(path)) {
+        path <- fs::path(getwd(), path)
+    }
+    path
 }
 

--- a/R/writers.R
+++ b/R/writers.R
@@ -31,20 +31,20 @@
 #' exist using `fs::dir_create()` with `recurse = TRUE`.
 #'
 #' @export
-#' @examplesTempdir
-#' # Writing a text file
+#' @examples
+#' # Write a text file into a temporary directory
 #' write_file_content(
 #'   content = "library(shiny)\n\nui <- fluidPage()",
-#'   file_path = "app/app.R",
+#'   file_path = file.path(tempdir(), "app", "app.R"),
 #'   type = "text"
 #' )
 #'
-#' # Write base64 encoded image
+#' # Write a base64-encoded image
 #' b64img <- paste0(
 #'   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA",
 #'   "DUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
 #' )
-#' write_file_content(b64img, "test.png", type = "binary")
+#' write_file_content(b64img, file.path(tempdir(), "test.png"), type = "binary")
 write_file_content <- function(content, file_path, type = "text") {
     # Ensure parent directory exists
     parent_dir <- dirname(file_path)
@@ -133,8 +133,12 @@ write_file_content <- function(content, file_path, type = "text") {
 #'    - Properly closes the code block
 #' 3. Writes the complete document to the specified path
 #'
+#' @return
+#' No return value, called for its side effect of writing a Quarto document
+#' to `qmd_path`.
+#'
 #' @export
-#' @examplesTempdir
+#' @examples
 #' # Example apps list structure
 #' apps <- list(
 #'   list(
@@ -153,7 +157,7 @@ write_file_content <- function(content, file_path, type = "text") {
 #'   )
 #' )
 #'
-#' write_apps_to_quarto(apps, "applications.qmd")
+#' write_apps_to_quarto(apps, file.path(tempdir(), "applications.qmd"))
 #' @seealso
 #' * [write_apps_to_dirs()] for alternative directory output format
 write_apps_to_quarto <- function(apps, qmd_path) {
@@ -283,12 +287,16 @@ write_apps_to_quarto <- function(apps, qmd_path) {
 #' }
 #' ```
 #'
+#' @return
+#' No return value, called for its side effect of writing one application
+#' subdirectory per app (plus a metadata file) under `base_dir`.
+#'
 #' @seealso
 #' - [padding_width()] for directory number padding calculation
 #' - [write_apps_to_quarto()] for alternative Quarto output format
 #'
 #' @export
-#' @examplesTempdir
+#' @examples
 #' # Example apps list structure
 #' apps <- list(
 #'   list(
@@ -315,7 +323,7 @@ write_apps_to_quarto <- function(apps, qmd_path) {
 #'   )
 #' )
 #'
-#' write_apps_to_dirs(apps, "extracted_apps")
+#' write_apps_to_dirs(apps, file.path(tempdir(), "extracted_apps"))
 write_apps_to_dirs <- function(apps, base_dir) {
     fs::dir_create(base_dir, recurse = TRUE)
 
@@ -375,8 +383,9 @@ write_apps_to_dirs <- function(apps, base_dir) {
 #'   object.
 #'
 #' @param output_dir Character string. Directory where application files should
-#'   be extracted. Defaults to `"converted_shiny_app"`. Will be created if it
-#'   doesn't exist. Existing files in this directory may be overwritten.
+#'   be extracted. A relative path is created under the current working
+#'   directory; an absolute path is used as-is. Will be created if it doesn't
+#'   exist. Existing files in this directory may be overwritten.
 #'
 #' @return
 #'  An object of class `"standalone_shinylive_app"` containing:
@@ -419,7 +428,7 @@ write_apps_to_dirs <- function(apps, base_dir) {
 #' - [validate_app_json()] for JSON data validation
 #'
 #' @export
-#' @examplesTempdir
+#' @examples
 #' # Example JSON data structure
 #' json_data <- list(
 #'   list(
@@ -437,9 +446,12 @@ write_apps_to_dirs <- function(apps, base_dir) {
 #' app <- write_standalone_shinylive_app(
 #'   json_data,
 #'   "https://example.com/app.json",
-#'   "my_app"
+#'   file.path(tempdir(), "my_app")
 #' )
-write_standalone_shinylive_app <- function(json_data, source_url, output_dir = "converted_shiny_app") {
+write_standalone_shinylive_app <- function(json_data, source_url, output_dir) {
+    # Resolve relative paths against the working directory
+    output_dir <- resolve_output_path(output_dir)
+
     # Create output directory
     fs::dir_create(output_dir, recurse = TRUE)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -92,28 +92,37 @@ For instance, if we take the main Shinylive extension website, we get:
 ```{r}
 #| label: peek-shinylive-app
 #| cache: true
-peeky::peek_shinylive_app("https://quarto-ext.github.io/shinylive/")
+# Choose where the files are written (here, a temporary directory)
+out_dir <- file.path(tempdir(), "shinylive-apps")
+peeky::peek_shinylive_app("https://quarto-ext.github.io/shinylive/", output_dir = out_dir)
 ```
 
 This would be equivalent to if we ran the following:
 
 ```r
-peeky::peek_quarto_shinylive_app("https://quarto-ext.github.io/shinylive/")
+peeky::peek_quarto_shinylive_app(
+  "https://quarto-ext.github.io/shinylive/",
+  output_path = out_dir
+)
 ```
 
-By default, the extracted files will be placed in the current working directory
-under the `converted_shiny_apps` directory. Each application will be placed in a
-subdirectory named `app_1`, `app_2`, etc. If we want to specify a different
-output directory, we can do so by providing the `output_path` argument. We
-can also specify the output format as `quarto` to extract the files into a
+The output location is a required argument, so the package never writes to your
+working directory unless you ask it to: a relative path such as `"my-apps"` is
+created under the current working directory, while an absolute path is used
+as-is. Each application is placed in a subdirectory named `app_1`, `app_2`,
+etc. We can also set the output format to `quarto` to extract the files into a
 single Quarto document.
 
 ```{r}
 #| label: peek-shinylive-app-output-dir
 #| cache: true
 
-# Extract the Shinylive application into a different directory
-peeky::peek_quarto_shinylive_app("https://quarto-ext.github.io/shinylive/", output_format = "quarto")
+# Extract the applications into a single Quarto document
+peeky::peek_quarto_shinylive_app(
+  "https://quarto-ext.github.io/shinylive/",
+  output_format = "quarto",
+  output_path = file.path(tempdir(), "shinylive-apps.qmd")
+)
 ```
 
 We can switch to the `peek_standalone_shinylive_app()` function if we know that
@@ -124,7 +133,10 @@ on GitHub, we get:
 ```{r}
 #| label: peek-shinylive-standalone-app
 #| cache: true
-peeky::peek_standalone_shinylive_app("https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/")
+peeky::peek_standalone_shinylive_app(
+  "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/",
+  output_dir = file.path(tempdir(), "standalone-app")
+)
 ```
 
 ## License
@@ -151,7 +163,7 @@ This package is for educational purposes. Users should:
 Thanks to the Shinylive, [webR](https://docs.r-wasm.org/webr/latest/) and [Pyodide](https://pyodide.org/en/stable/) teams for enabling browser-based data science.
 
 [quarto]: https://quarto.org
-[slexplain]: https://shiny.posit.co/py/docs/shinylive.html
+[slexplain]: https://shiny.posit.co/py/get-started/shinylive.html
 [qsl]: https://github.com/quarto-ext/shinylive
 [webr]: https://docs.r-wasm.org/webr/latest/
 [pyodide]: https://pyodide.org/en/stable/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The `peeky` package helps you extract, examine, and run the source code
 from Shiny applications that have been converted to run in the browser
-using [Shinylive](https://shiny.posit.co/py/docs/shinylive.html). It
+using [Shinylive](https://shiny.posit.co/py/get-started/shinylive.html). It
 works with both standalone applications and [Quarto](https://quarto.org)
 documents containing Shinylive components through the
 [quarto-shinylive](https://github.com/quarto-ext/shinylive) extension,
@@ -18,7 +18,7 @@ supporting both R and Python Shiny applications.
 
 ## About Shinylive
 
-[Shinylive](https://shiny.posit.co/py/docs/shinylive.html) converts
+[Shinylive](https://shiny.posit.co/py/get-started/shinylive.html) converts
 existing Shiny applications to run entirely in the web browser using
 [WebAssembly](https://webassembly.org/) versions of R
 ([webR](https://docs.r-wasm.org/webr/latest/)) and Python
@@ -90,45 +90,57 @@ Shinylive components. For instance, if we take the main Shinylive
 extension website, we get:
 
 ``` r
-peeky::peek_shinylive_app("https://quarto-ext.github.io/shinylive/")
+# Choose where the files are written (here, a temporary directory)
+out_dir <- file.path(tempdir(), "shinylive-apps")
+peeky::peek_shinylive_app("https://quarto-ext.github.io/shinylive/", output_dir = out_dir)
 #> 
 #> ── Shinylive Applications ──────────────────────────────────────────────────────
 #> 
 #> ── Shiny for Python Applications ──
 #> 
 #> Run in Terminal:
-#> shiny run --reload --launch-browser "/Users/ronin/Documents/GitHub/r-pkg/peeky/converted_shiny_app/app_1/app.py"
-#> shiny run --reload --launch-browser "/Users/ronin/Documents/GitHub/r-pkg/peeky/converted_shiny_app/app_2/app.py"
-#> shiny run --reload --launch-browser "/Users/ronin/Documents/GitHub/r-pkg/peeky/converted_shiny_app/app_3/app.py"
-#> shiny run --reload --launch-browser "/Users/ronin/Documents/GitHub/r-pkg/peeky/converted_shiny_app/app_4/app.py"
+#> shiny run --reload --launch-browser "/tmp/RtmpXXXXXX/shinylive-apps/app_1/app.py"
+#> shiny run --reload --launch-browser "/tmp/RtmpXXXXXX/shinylive-apps/app_2/app.py"
+#> shiny run --reload --launch-browser "/tmp/RtmpXXXXXX/shinylive-apps/app_3/app.py"
+#> shiny run --reload --launch-browser "/tmp/RtmpXXXXXX/shinylive-apps/app_4/app.py"
 ```
 
 This would be equivalent to if we ran the following:
 
 ``` r
-peeky::peek_quarto_shinylive_app("https://quarto-ext.github.io/shinylive/")
+peeky::peek_quarto_shinylive_app(
+  "https://quarto-ext.github.io/shinylive/",
+  output_path = out_dir
+)
 ```
 
-By default, the extracted files will be placed in the current working
-directory under the `converted_shiny_apps` directory. Each application
-will be placed in a subdirectory named `app_1`, `app_2`, etc. If we want
-to specify a different output directory, we can do so by providing the
-`output_path` argument. We can also specify the output format as
-`quarto` to extract the files into a single Quarto document.
+The output location is a required argument, so the package never writes to
+your working directory unless you ask it to: a relative path such as
+`"my-apps"` is created under the current working directory, while an absolute
+path is used as-is. Each application is placed in a subdirectory named
+`app_1`, `app_2`, etc. We can also set the output format to `quarto` to
+extract the files into a single Quarto document.
 
 ``` r
-# Extract the Shinylive application into a different directory
-peeky::peek_quarto_shinylive_app("https://quarto-ext.github.io/shinylive/", output_format = "quarto")
+# Extract the applications into a single Quarto document
+peeky::peek_quarto_shinylive_app(
+  "https://quarto-ext.github.io/shinylive/",
+  output_format = "quarto",
+  output_path = file.path(tempdir(), "shinylive-apps.qmd")
+)
 #> 
 #> ── Quarto Document with Shinylive Applications ─────────────────────────────────
 #> 
 #> ── Setup and Preview Steps ──
 #> 
-#> Step 1: Install the Shinylive extension:
+#> Step 1: Change to the document directory:
+#> cd "/tmp/RtmpXXXXXX"
+#> 
+#> Step 2: Install the Shinylive extension:
 #> quarto add quarto-ext/shinylive
 #> 
-#> Step 2: Preview the document:
-#> quarto preview "converted_shiny_apps.qmd"
+#> Step 3: Preview the document:
+#> quarto preview "shinylive-apps.qmd"
 #> 
 #> ── Contents ──
 #> 
@@ -144,12 +156,15 @@ app](https://github.com/coatless-tutorials/convert-shiny-app-r-shinylive)
 on GitHub, we get:
 
 ``` r
-peeky::peek_standalone_shinylive_app("https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/")
+peeky::peek_standalone_shinylive_app(
+  "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/",
+  output_dir = file.path(tempdir(), "standalone-app")
+)
 #> 
 #> ── Standalone Shinylive Application ────────────────────────────────────────────
 #> Type: R Shiny
 #> Run in R:
-#> shiny::runApp("/Users/ronin/Documents/GitHub/r-pkg/peeky/converted_shiny_app")
+#> shiny::runApp("/tmp/RtmpXXXXXX/standalone-app")
 #> 
 #> ── Contents ──
 #> 
@@ -160,7 +175,7 @@ peeky::peek_standalone_shinylive_app("https://tutorials.thecoatlessprofessor.com
 #> 
 #> Total files: 2
 #> 
-#> Location: '/Users/ronin/Documents/GitHub/r-pkg/peeky/converted_shiny_app'
+#> Location: '/tmp/RtmpXXXXXX/standalone-app'
 ```
 
 ## License

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,12 +1,41 @@
+## Resubmission
+
+This is a resubmission. In response to the CRAN review (2025-01-17), I have
+made the following changes:
+
+* Software, package, and API names ('shinylive', 'shiny', 'quarto') are written
+  in single quotes in the Title and Description.
+
+* There are no references describing methods to cite: the package is a tool for
+  retrieving and extracting the source of published 'shinylive' applications.
+
+* Added `\value` tags documenting the return value for the exported print
+  methods (`print.quarto_shinylive_apps()`,
+  `print.standalone_shinylive_app()`), describing the returned object (class)
+  and the side effects.
+
+* Removed the examples from the unexported (internal) helper functions
+  (`find_shinylive_app_json()`, `find_shinylive_code()`, `parse_code_block()`,
+  `parse_yaml_options()`, `validate_app_json()`).
+
+* Removed all remaining `\dontrun{}`. The examples for the exported `peek_*()`
+  functions download live applications from the internet, so they are wrapped
+  with `@examplesIf interactive()`.
+
+* The writing functions no longer use a default output path. The output
+  directory / file is now a required argument, so the package never writes to
+  the user's working directory (or anywhere in the user's file space) unless
+  the caller explicitly requests it. All examples, tests, and the vignette
+  write to `tempdir()` (or are non-executable display-only code blocks).
+
 ## R CMD check results
 
 0 errors | 0 warnings | 1 note
 
-* This is a new release.
+* This is a new submission.
 
-* Possibly misspelled words in DESCRIPTION:
-  Shinylive (2:29, 6:57)
-  json (8:46)
-  
-* Neither word is misspelled. These are names of technology being used. 
-  We've attempted to quiet this warning by incorporating them into the `inst/WORDLIST`. 
+* The NOTE reports two URLs as possibly invalid:
+  <https://pyodide.org/en/stable/> and
+  <https://pyodide.org/en/stable/usage/packages-in-pyodide.html>.
+  Both return HTTP 429 (Too Many Requests) to the automated checker but are
+  valid and load correctly in a browser; the 429 is transient rate limiting.

--- a/inst/01-demo-polyglot-shinylive-standalone-and-quarto-apps.R
+++ b/inst/01-demo-polyglot-shinylive-standalone-and-quarto-apps.R
@@ -1,10 +1,10 @@
 # Embedded Python Shinylive Applications in a Quarto Document
 peeky::peek_shinylive_app(
     "https://quarto-ext.github.io/shinylive",
-    output_dir = "quarto-shiny-apps")
+    output_dir = file.path(tempdir(), "quarto-shiny-apps"))
 
 # Standalone R Shinylive Application
 peeky::peek_shinylive_app(
     "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/",
-    output_dir = "r-shiny-app")
+    output_dir = file.path(tempdir(), "r-shiny-app"))
 

--- a/inst/02-demo-complex-apps.R
+++ b/inst/02-demo-complex-apps.R
@@ -1,10 +1,10 @@
 # Module/Script file heavy
 peeky::peek_shinylive_app(
     "https://shiny.thecoatlessprofessor.com/probability-distribution-explorer/",
-    output_dir = "probability-distribution-explorer")
+    output_dir = file.path(tempdir(), "probability-distribution-explorer"))
 
 # Resource rich
 peeky::peek_shinylive_app(
     "https://jeanjoe.net/peeky_example/",
-    output_dir = "peeky-example-data")
+    output_dir = file.path(tempdir(), "peeky-example-data"))
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,2 +1,3 @@
-json
 Shinylive
+shinylive
+json

--- a/man/find_shinylive_app_json.Rd
+++ b/man/find_shinylive_app_json.Rd
@@ -40,18 +40,4 @@ The function performs the following steps:
 }
 }
 }
-\examples{
-\dontrun{
-# Direct app.json URL
-result <- find_shinylive_app_json("https://example.com/app.json")
-
-# Directory containing app.json
-result <- find_shinylive_app_json("https://example.com/myapp/")
-
-# Check if valid
-if (result$valid) {
-  cat("Found app.json at:", result$url)
-}
-}
-}
 \keyword{internal}

--- a/man/find_shinylive_code.Rd
+++ b/man/find_shinylive_code.Rd
@@ -44,22 +44,6 @@ The function performs the following steps:
 Code blocks should follow the Shinylive format with optional YAML-style
 options (prefixed with \code{'#|'}) and file markers (prefixed with \code{'## file:'}).
 }
-\examples{
-\dontrun{
-html_content <- '
-<pre class="shinylive-r" data-engine="r">
-#| viewerHeight: 500
-## file: app.R
-library(shiny)
-ui <- fluidPage()
-server <- function(input, output) {}
-shinyApp(ui, server)
-</pre>
-'
-apps <- find_shinylive_code(html_content)
-}
-
-}
 \seealso{
 parse_code_block
 }

--- a/man/parse_code_block.Rd
+++ b/man/parse_code_block.Rd
@@ -50,32 +50,6 @@ automatically placed in:
 }
 }
 
-\examples{
-\dontrun{
-# Single-file R application
-code <- '
-#| viewerHeight: 500
-library(shiny)
-ui <- fluidPage()
-server <- function(input, output) {}
-shinyApp(ui, server)
-'
-result1 <- parse_code_block(code, "r")
-
-# Multi-file Python application
-code <- '
-#| fullWidth: true
-## file: app.py
-from shiny import App, ui
-app = App(app_ui)
-## file: requirements.txt
-## type: text
-shiny>=0.5.0
-'
-result2 <- parse_code_block(code, "python")
-}
-
-}
 \seealso{
 \itemize{
 \item \code{\link[=parse_yaml_options]{parse_yaml_options()}} for YAML-style option parsing

--- a/man/parse_yaml_options.Rd
+++ b/man/parse_yaml_options.Rd
@@ -36,26 +36,6 @@ The function handles several value types:
 
 Lines that don't contain a colon (\code{':'}) are ignored.
 }
-\examples{
-\dontrun{
-# Parse various types of options
-yaml_lines <- c(
-  "#| viewerHeight: 500",
-  "#| components: [slider,button]",
-  "#| fullWidth: true",
-  "#| title: My App"
-)
-options <- parse_yaml_options(yaml_lines)
-# Results in:
-# list(
-#   viewerHeight = 500,
-#   components = c("slider", "button"),
-#   fullWidth = TRUE,
-#   title = "My App"
-# )
-}
-
-}
 \seealso{
 parse_code_block
 }

--- a/man/peek_quarto_shinylive_app.Rd
+++ b/man/peek_quarto_shinylive_app.Rd
@@ -7,7 +7,7 @@
 peek_quarto_shinylive_app(
   url,
   output_format = c("app-dir", "quarto"),
-  output_path = NULL
+  output_path
 )
 }
 \arguments{
@@ -22,11 +22,12 @@ extracted. Must be one of:
 \item \code{"quarto"}: Combines all applications into a single Quarto document
 }}
 
-\item{output_path}{Character string or NULL. Where to write the extracted
-applications. If NULL, uses default paths:
+\item{output_path}{Character string. Where to write the extracted
+applications. A relative path is resolved against the current working
+directory; an absolute path is used as-is.
 \itemize{
-\item For "app-dir": "./converted_shiny_apps/"
-\item For "quarto": "./converted_shiny_apps.qmd"
+\item For \code{"app-dir"}: a directory that will hold the extracted applications
+\item For \code{"quarto"}: the path of the \code{.qmd} file to create
 }}
 }
 \value{
@@ -77,18 +78,19 @@ The function will error with informative messages if:
 }
 
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-# Extract as separate applications
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
+# Extract as separate application directories under a temporary directory
 result <- peek_quarto_shinylive_app(
   "https://quarto-ext.github.io/shinylive",
-  output_format = "app-dir"
+  output_format = "app-dir",
+  output_path = file.path(tempdir(), "quarto_apps")
 )
 
 # Combine into a new Quarto document
 result <- peek_quarto_shinylive_app(
   "https://quarto-ext.github.io/shinylive",
   output_format = "quarto",
-  output_path = "my_apps.qmd"
+  output_path = file.path(tempdir(), "my_apps.qmd")
 )
 
 # Print will show instructions for running the apps

--- a/man/peek_shinylive_app.Rd
+++ b/man/peek_shinylive_app.Rd
@@ -4,7 +4,7 @@
 \alias{peek_shinylive_app}
 \title{Download and Extract Shinylive Applications from URLs}
 \usage{
-peek_shinylive_app(url, output_dir = "converted_shiny_app")
+peek_shinylive_app(url, output_dir)
 }
 \arguments{
 \item{url}{Character string. URL pointing to one of:
@@ -15,7 +15,8 @@ peek_shinylive_app(url, output_dir = "converted_shiny_app")
 }}
 
 \item{output_dir}{Character string. Directory where the application files should
-be extracted. Defaults to \code{"converted_shiny_app"}. Will be created if it doesn't exist.}
+be extracted. A relative path is created under the current working directory;
+an absolute path is used as-is. The directory will be created if it doesn't exist.}
 }
 \value{
 An object containing the extracted application information:
@@ -78,20 +79,16 @@ The function will error with informative messages if:
 }
 
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-# Download a standalone Shinylive application
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
+# Write the extracted files to the session's temporary directory
 url <- "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/"
-
-app <- peek_shinylive_app(url)
-
-# Extract to a specific directory
-app <- peek_shinylive_app(
-  url,
-  output_dir = "my_extracted_app"
-)
+app <- peek_shinylive_app(url, output_dir = file.path(tempdir(), "my_extracted_app"))
 
 # Download from a Quarto document
-apps <- peek_shinylive_app("https://quarto-ext.github.io/shinylive/")
+apps <- peek_shinylive_app(
+  "https://quarto-ext.github.io/shinylive/",
+  output_dir = file.path(tempdir(), "my_extracted_apps")
+)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/peek_standalone_shinylive_app.Rd
+++ b/man/peek_standalone_shinylive_app.Rd
@@ -4,7 +4,7 @@
 \alias{peek_standalone_shinylive_app}
 \title{Download and Extract a Standalone Shinylive Application}
 \usage{
-peek_standalone_shinylive_app(url, output_dir = "converted_shiny_app")
+peek_standalone_shinylive_app(url, output_dir)
 }
 \arguments{
 \item{url}{Character string. URL pointing to either:
@@ -16,9 +16,9 @@ peek_standalone_shinylive_app(url, output_dir = "converted_shiny_app")
 The function will automatically append \code{"app.json"} to directory URLs.}
 
 \item{output_dir}{Character string. Directory where the application files
-should be extracted. Defaults to \code{"converted_shiny_app"}. Will be created
-if it doesn't exist. If the directory already exists, files may be
-overwritten.}
+should be extracted. A relative path is created under the current working
+directory; an absolute path is used as-is. Will be created if it doesn't
+exist. If the directory already exists, files may be overwritten.}
 }
 \value{
 An object of class \code{"standalone_shinylive_app"} containing:
@@ -66,17 +66,17 @@ The function will error with informative messages if:
 }
 
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-
-# Download from a direct app.json URL
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
+# Download from a direct app.json URL into a temporary directory
 app <- peek_standalone_shinylive_app(
-  "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/app.json"
+  "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/app.json",
+  output_dir = file.path(tempdir(), "standalone_app")
 )
 
 # Download from a directory URL (app.json will be appended)
 app <- peek_standalone_shinylive_app(
   "https://tutorials.thecoatlessprofessor.com/convert-shiny-app-r-shinylive/",
-  output_dir = "my_local_app"
+  output_dir = file.path(tempdir(), "my_local_app")
 )
 
 # Print shows how to run the application

--- a/man/peeky-package.Rd
+++ b/man/peeky-package.Rd
@@ -20,5 +20,10 @@ Useful links:
 \author{
 \strong{Maintainer}: James Joseph Balamuta \email{james.balamuta@gmail.com}
 
+Authors:
+\itemize{
+  \item James Joseph Balamuta \email{james.balamuta@gmail.com}
+}
+
 }
 \keyword{internal}

--- a/man/print.quarto_shinylive_apps.Rd
+++ b/man/print.quarto_shinylive_apps.Rd
@@ -11,6 +11,16 @@
 
 \item{...}{Additional arguments passed to print}
 }
+\value{
+Invisibly returns the original object of class \code{quarto_shinylive_apps}.
+Primarily called for its side effect of displaying formatted information about:
+\itemize{
+\item Application types (R/Python)
+\item Commands to run each application
+\item File contents and organization
+\item Output locations
+}
+}
 \description{
 Print method for \code{quarto_shinylive_apps} objects
 }

--- a/man/print.standalone_shinylive_app.Rd
+++ b/man/print.standalone_shinylive_app.Rd
@@ -11,6 +11,16 @@
 
 \item{...}{Additional arguments passed to print}
 }
+\value{
+Invisibly returns the original object of class \code{standalone_shinylive_app}.
+Primarily called for its side effect of displaying formatted information about:
+\itemize{
+\item Application type (R/Python)
+\item Command to run the application
+\item List of extracted files by type
+\item File locations
+}
+}
 \description{
 Print method for \code{standalone_shinylive_app} objects
 }

--- a/man/validate_app_json.Rd
+++ b/man/validate_app_json.Rd
@@ -72,30 +72,6 @@ a file in the application.
 }\if{html}{\out{</div>}}
 }
 
-\examples{
-\dontrun{
-# Valid structure
-valid_data <- list(
-  list(
-    name = "app.R",
-    content = "library(shiny)\n...",
-    type = "text"
-  ),
-  list(
-    name = "data.csv",
-    content = "x,y\n1,2",
-    type = "text"
-  )
-)
-validate_app_json(valid_data)  # Returns TRUE
-
-# Invalid structures that will error:
-validate_app_json(list())  # Empty list
-validate_app_json(list(
-  list(name = "app.R")  # Missing required fields
-))
-}
-}
 \seealso{
 \itemize{
 \item \code{\link[=find_shinylive_app_json]{find_shinylive_app_json()}} which uses this validation

--- a/man/write_apps_to_dirs.Rd
+++ b/man/write_apps_to_dirs.Rd
@@ -23,6 +23,10 @@ contain:
 \item{base_dir}{Character string. Base directory where application
 subdirectories should be created. Will be created if it doesn't exist.}
 }
+\value{
+No return value, called for its side effect of writing one application
+subdirectory per app (plus a metadata file) under \code{base_dir}.
+}
 \description{
 Takes a list of parsed Shinylive applications and writes each to its own
 numbered subdirectory. Creates consistently numbered directories with proper
@@ -75,9 +79,6 @@ Each directory includes a \code{shinylive_metadata.json} file containing:
 }
 
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir
-}
 # Example apps list structure
 apps <- list(
   list(
@@ -104,10 +105,7 @@ apps <- list(
   )
 )
 
-write_apps_to_dirs(apps, "extracted_apps")
-\dontshow{
-setwd(.old_wd) # examplesTempdir
-}
+write_apps_to_dirs(apps, file.path(tempdir(), "extracted_apps"))
 }
 \seealso{
 \itemize{

--- a/man/write_apps_to_dirs.Rd
+++ b/man/write_apps_to_dirs.Rd
@@ -76,7 +76,7 @@ Each directory includes a \code{shinylive_metadata.json} file containing:
 
 \examples{
 \dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir 
+.old_wd <- setwd(tempdir()) # examplesTempdir
 }
 # Example apps list structure
 apps <- list(
@@ -106,7 +106,7 @@ apps <- list(
 
 write_apps_to_dirs(apps, "extracted_apps")
 \dontshow{
-setwd(.old_wd) # examplesTempdir 
+setwd(.old_wd) # examplesTempdir
 }
 }
 \seealso{

--- a/man/write_apps_to_quarto.Rd
+++ b/man/write_apps_to_quarto.Rd
@@ -24,6 +24,10 @@ contain:
 written. Should end with \code{.qmd} extension. Parent directory will be created
 if it doesn't exist.}
 }
+\value{
+No return value, called for its side effect of writing a Quarto document
+to \code{qmd_path}.
+}
 \description{
 Converts a list of parsed Shinylive applications into a single Quarto document.
 Creates a properly formatted .qmd file with YAML frontmatter, organized sections
@@ -88,9 +92,6 @@ Options are converted to YAML format based on their type:
 }
 
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir
-}
 # Example apps list structure
 apps <- list(
   list(
@@ -109,10 +110,7 @@ apps <- list(
   )
 )
 
-write_apps_to_quarto(apps, "applications.qmd")
-\dontshow{
-setwd(.old_wd) # examplesTempdir
-}
+write_apps_to_quarto(apps, file.path(tempdir(), "applications.qmd"))
 }
 \seealso{
 \itemize{

--- a/man/write_apps_to_quarto.Rd
+++ b/man/write_apps_to_quarto.Rd
@@ -89,7 +89,7 @@ Options are converted to YAML format based on their type:
 
 \examples{
 \dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir 
+.old_wd <- setwd(tempdir()) # examplesTempdir
 }
 # Example apps list structure
 apps <- list(
@@ -111,7 +111,7 @@ apps <- list(
 
 write_apps_to_quarto(apps, "applications.qmd")
 \dontshow{
-setwd(.old_wd) # examplesTempdir 
+setwd(.old_wd) # examplesTempdir
 }
 }
 \seealso{

--- a/man/write_file_content.Rd
+++ b/man/write_file_content.Rd
@@ -47,7 +47,7 @@ exist using \code{fs::dir_create()} with \code{recurse = TRUE}.
 }
 \examples{
 \dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir 
+.old_wd <- setwd(tempdir()) # examplesTempdir
 }
 # Writing a text file
 write_file_content(
@@ -63,6 +63,6 @@ b64img <- paste0(
 )
 write_file_content(b64img, "test.png", type = "binary")
 \dontshow{
-setwd(.old_wd) # examplesTempdir 
+setwd(.old_wd) # examplesTempdir
 }
 }

--- a/man/write_file_content.Rd
+++ b/man/write_file_content.Rd
@@ -46,23 +46,17 @@ Parent directories in the file path are automatically created if they don't
 exist using \code{fs::dir_create()} with \code{recurse = TRUE}.
 }
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir
-}
-# Writing a text file
+# Write a text file into a temporary directory
 write_file_content(
   content = "library(shiny)\n\nui <- fluidPage()",
-  file_path = "app/app.R",
+  file_path = file.path(tempdir(), "app", "app.R"),
   type = "text"
 )
 
-# Write base64 encoded image
+# Write a base64-encoded image
 b64img <- paste0(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA",
   "DUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
 )
-write_file_content(b64img, "test.png", type = "binary")
-\dontshow{
-setwd(.old_wd) # examplesTempdir
-}
+write_file_content(b64img, file.path(tempdir(), "test.png"), type = "binary")
 }

--- a/man/write_standalone_shinylive_app.Rd
+++ b/man/write_standalone_shinylive_app.Rd
@@ -73,7 +73,7 @@ Expected JSON data structure:
 
 \examples{
 \dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir 
+.old_wd <- setwd(tempdir()) # examplesTempdir
 }
 # Example JSON data structure
 json_data <- list(
@@ -95,7 +95,7 @@ app <- write_standalone_shinylive_app(
   "my_app"
 )
 \dontshow{
-setwd(.old_wd) # examplesTempdir 
+setwd(.old_wd) # examplesTempdir
 }
 }
 \seealso{

--- a/man/write_standalone_shinylive_app.Rd
+++ b/man/write_standalone_shinylive_app.Rd
@@ -4,11 +4,7 @@
 \alias{write_standalone_shinylive_app}
 \title{Write Standalone Shinylive Application Files from JSON Data}
 \usage{
-write_standalone_shinylive_app(
-  json_data,
-  source_url,
-  output_dir = "converted_shiny_app"
-)
+write_standalone_shinylive_app(json_data, source_url, output_dir)
 }
 \arguments{
 \item{json_data}{List. Parsed JSON data from a Shinylive \code{app.json} file.
@@ -24,8 +20,9 @@ was downloaded. Used for reference and provenance tracking in the returned
 object.}
 
 \item{output_dir}{Character string. Directory where application files should
-be extracted. Defaults to \code{"converted_shiny_app"}. Will be created if it
-doesn't exist. Existing files in this directory may be overwritten.}
+be extracted. A relative path is created under the current working
+directory; an absolute path is used as-is. Will be created if it doesn't
+exist. Existing files in this directory may be overwritten.}
 }
 \value{
 An object of class \code{"standalone_shinylive_app"} containing:
@@ -72,9 +69,6 @@ Expected JSON data structure:
 }
 
 \examples{
-\dontshow{
-.old_wd <- setwd(tempdir()) # examplesTempdir
-}
 # Example JSON data structure
 json_data <- list(
   list(
@@ -92,11 +86,8 @@ json_data <- list(
 app <- write_standalone_shinylive_app(
   json_data,
   "https://example.com/app.json",
-  "my_app"
+  file.path(tempdir(), "my_app")
 )
-\dontshow{
-setwd(.old_wd) # examplesTempdir
-}
 }
 \seealso{
 \itemize{

--- a/tests/testthat/test-peek.R
+++ b/tests/testthat/test-peek.R
@@ -31,8 +31,12 @@ test_that("peek_shinylive_app(): handles HTML content correctly", {
         .package = "httr"
     )
 
+    # Create a temporary directory for output
+    temp_dir <- base::tempfile()
+    base::on.exit(base::unlink(temp_dir, recursive = TRUE))
+
     # Test the function with a sample URL
-    result <- peek_shinylive_app("http://example.com")
+    result <- peek_shinylive_app("http://example.com", output_dir = temp_dir)
 
     # Verify the result is a quarto_shinylive_apps object
     testthat::expect_s3_class(result, "quarto_shinylive_apps")
@@ -63,8 +67,12 @@ test_that("peek_shinylive_app(): handles app.json content correctly", {
         .package = "httr"
     )
 
+    # Create a temporary directory for output
+    temp_dir <- base::tempfile()
+    base::on.exit(base::unlink(temp_dir, recursive = TRUE))
+
     # Test the function with a URL pointing to app.json
-    result <- peek_shinylive_app("http://example.com/app.json")
+    result <- peek_shinylive_app("http://example.com/app.json", output_dir = temp_dir)
 
     # Verify the result is a standalone_shinylive_app object
     testthat::expect_s3_class(result, "standalone_shinylive_app")

--- a/vignettes/behind-the-scenes.qmd
+++ b/vignettes/behind-the-scenes.qmd
@@ -320,7 +320,7 @@ peeky::peek_standalone_shinylive_app(
 # For Quarto-embedded applications
 peeky::peek_quarto_shinylive_app(
   url = "https://coatless-quarto.github.io/r-shinylive-demo/",
-  output_dir = "extracted_quarto",
+  output_path = "extracted_quarto",
   output_format = "app-dir"  # or "quarto"
 )
 ```
@@ -354,7 +354,8 @@ When working with Quarto documents containing multiple Shinylive applications,
 # Extract as separate application directories
 peeky::peek_quarto_shinylive_app(
   url = "https://quarto-ext.github.io/shinylive",
-  output_format = "app-dir"
+  output_format = "app-dir",
+  output_path = "extracted_quarto"
 )
 # Results in:
 # extracted_quarto/
@@ -366,7 +367,8 @@ peeky::peek_quarto_shinylive_app(
 # Reconstruct as a new Quarto document
 peeky::peek_quarto_shinylive_app(
   url = "https://quarto-ext.github.io/shinylive",
-  output_format = "quarto"
+  output_format = "quarto",
+  output_path = "extracted_quarto.qmd"
 )
 # Results in a single .qmd file containing all applications
 ```
@@ -485,7 +487,7 @@ Thanks to the Shinylive, [webR](https://docs.r-wasm.org/webr/latest/) and [Pyodi
 5. [Shiny Standalone webR Demo][protoslr]
 
 [quarto]: https://quarto.org
-[slexplain]: https://shiny.posit.co/py/docs/shinylive.html
+[slexplain]: https://shiny.posit.co/py/get-started/shinylive.html
 [qsl]: https://github.com/quarto-ext/shinylive
 [webr]: https://docs.r-wasm.org/webr/latest/
 [webrpkg]: https://repo.r-wasm.org/


### PR DESCRIPTION
Resolves the CRAN reviewer feedback for the 0.1.0 submission and drops the `rocleteer` dev dependency so docs build with stock roxygen2.

## Changes
- **`\value`** documented for every exported function (both print methods and both writers included).
- **Examples** removed from unexported helpers; all `\dontrun{}` gone (network examples use `@examplesIf interactive()`).
- **No default writes:** `output_dir`/`output_path` are now required; relative paths resolve under the working directory; examples, tests, vignette, README, and `inst/` demos all write to `tempdir()`.
- **Tooling:** replaced `rocleteer`'s `@examplesTempdir` roclet with stock roxygen2 and regenerated docs.
- **Check NOTEs:** fixed dead Shinylive docs URL (404 → `/py/get-started/`) and added `shinylive` to `inst/WORDLIST`.

## Check
`R CMD check --as-cran`: **0 errors | 0 warnings | 1 note** — the note is "new submission" plus two `pyodide.org` URLs returning transient `429`s (valid pages).
